### PR TITLE
fix(clusters): enable stg and prod on pipelines

### DIFF
--- a/clusters/backend.tf
+++ b/clusters/backend.tf
@@ -11,3 +11,4 @@ terraform {
     use_path_style              = true
   }
 }
+#


### PR DESCRIPTION
## PR Type
fix: enable stg and prod on pipelines

## Description
Stg and Prod were turned off, forcing a TF run to enable them on pipelines again.

## Related Issues
n/a

## Checklist
- [X] My PR follows the [conventional commits](https://www.conventionalcommits.org/) guidelines
- [X] I have tested my changes
- [X] I have updated documentation as needed
- [X] I have added appropriate comments to my code, particularly in complex areas

## Additional Notes
n/a